### PR TITLE
backport: add missing generic backports label when backport action fails

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backport",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "license": "MIT",
   "main": "dist/index.js",
   "files": [

--- a/src/backport.ts
+++ b/src/backport.ts
@@ -333,7 +333,11 @@ const backport = async ({
           "POST /repos/{owner}/{repo}/issues/{issue_number}/labels",
           {
             issue_number: number,
-            labels: ["release-blocker", `failed-backport-to-${base}`],
+            labels: [
+              "backports",
+              "release-blocker",
+              `failed-backport-to-${base}`,
+            ],
             owner,
             repo,
           },


### PR DESCRIPTION
When backporting fails it doesn't add the generic backports label this should resolve that to be able to capture all backport PR's