### PR TITLE
backport: Include GH action run link in comment when job fails

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -23,19 +23,25 @@ const run = async () => {
     }
 
     const payload = context.payload as PullRequestEvent;
+    const runId = context.runId; 
+    const runNumber = context.runNumber;
+    const serverUrl = context.serverUrl;
 
     if (payload.action !== "closed" && payload.action !== "labeled") {
       throw new Error(
         `Unsupported pull request event action: ${payload.action}.`,
       );
     }
-
+  
     const createdPullRequestBaseBranchToNumber = await backport({
       getBody,
       getHead,
       getTitle,
       labelRegExp,
       payload,
+      runId,
+      runNumber,
+      serverUrl,
       token,
     });
     setOutput(


### PR DESCRIPTION
This change automatically adds a GitHub Action run link in the comment section upon job failure, making it easier and quicker for devs to troubleshoot why their PR backports are failing.

relates to: https://sourcegraph.slack.com/archives/C04MYFW01NV/p1687195586357239

