### PR TITLE
backport: add instruction for removing `release-blocker` label during manual backport

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backport",
-  "version": "2.0.4",
+  "version": "2.0.6",
   "license": "MIT",
   "main": "dist/index.js",
   "files": [

--- a/src/backport.ts
+++ b/src/backport.ts
@@ -194,6 +194,7 @@ const getFailedBackportCommentBody = ({
     `Then, create a pull request where the \`base\` branch is \`${base}\` and the \`compare\`/\`head\` branch is \`${head}\`.`,
     `See ${runUrl} for more information.`,
     "Make sure to tag `@sourcegraph/release-guild` in the pull request description.",
+    "Once the backport pull request is created, kindly remove the `release-blocker` from this pull request."
   ].join("\n");
 };
 


### PR DESCRIPTION
This PR adds an instruction for PR authors to remove the `release-blocker` label during manual backporting.
This allows the release captain to have an idea of PRs that failed during the auto-backport and haven't been manually backported.