### PR TITLE
improve backport experience

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,6 @@ const run = async () => {
 
     const payload = context.payload as PullRequestEvent;
     const runId = context.runId; 
-    const runNumber = context.runNumber;
     const serverUrl = context.serverUrl;
 
     if (payload.action !== "closed" && payload.action !== "labeled") {
@@ -40,7 +39,6 @@ const run = async () => {
       labelRegExp,
       payload,
       runId,
-      runNumber,
       serverUrl,
       token,
     });


### PR DESCRIPTION
the current experience is quite bad when you run into conflict, I prefer to have commands I can just copy and paste to resume the process

post-creation step is easy to miss, i.e., remove `release-blocker` label

https://github.com/sourcegraph/sourcegraph/pull/56448#issuecomment-1711833003