### PR TITLE
release: add more info on manual backports

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backport",
-  "version": "2.0.9",
+  "version": "2.0.10",
   "license": "MIT",
   "main": "dist/index.js",
   "files": [

--- a/src/backport.ts
+++ b/src/backport.ts
@@ -159,15 +159,15 @@ const getFailedBackportCommentBody = ({
   commitSha,
   errorMessage,
   head,
-  runUrl,
   prNumber,
+  runUrl,
 }: {
   base: string;
   commitSha: string;
   errorMessage: string;
   head: string;
-  runUrl: string;
   prNumber: number;
+  runUrl: string;
 }) => {
   const worktreePath = `.worktrees/backport-${base}`;
   return `The backport to \`${base}\` failed at ${runUrl}:
@@ -369,8 +369,8 @@ const backport = async ({
               commitSha: mergeCommitSha,
               errorMessage: error.message,
               head,
-              runUrl,
               prNumber,
+              runUrl,
             }),
             issue_number: prNumber,
             owner,

--- a/src/backport.ts
+++ b/src/backport.ts
@@ -160,6 +160,7 @@ const getFailedBackportCommentBody = ({
   errorMessage,
   head,
   runUrl,
+  prNumber,
 }: {
   base: string;
   commitSha: string;
@@ -168,48 +169,70 @@ const getFailedBackportCommentBody = ({
   runUrl: string;
 }) => {
   const worktreePath = `.worktrees/backport-${base}`;
-  return [
-    `The backport to \`${base}\` failed at ${runUrl}:`,
-    "```",
-    errorMessage,
-    "```",
-    "To backport manually, run these commands in your terminal:",
-    "```bash",
-    "# Fetch latest updates from GitHub",
-    "git fetch",
-    "# Create a new working tree",
-    `git worktree add ${worktreePath} ${base}`,
-    "# Navigate to the new working tree",
-    `cd ${worktreePath}`,
-    "# Create a new branch",
-    `git switch --create ${head}`,
-    "# Cherry-pick the merged commit of this pull request and resolve the conflicts",
-    `git cherry-pick -x --mainline 1 ${commitSha}`,
-    "# Push it to GitHub",
-    `git push --set-upstream origin ${head}`,
-    "# Go back to the original working tree",
-    "cd ../..",
-    "# Delete the working tree",
-    `git worktree remove ${worktreePath}`,
-    "```",
-    "If you encouter conflict, first resolve the conflict and stage all files, then run the commands below:",
-    "```bash",
-    "git cherry-pick --continue",
-    "# Push it to GitHub",
-    `git push --set-upstream origin ${head}`,
-    "# Go back to the original working tree",
-    "cd ../..",
-    "# Delete the working tree",
-    `git worktree remove ${worktreePath}`,
-    "```",
-    "",
-    "- [ ] Follow above instructions to backport the commit.",
-    `- [ ] Create a pull request where the \`base\` branch is \`${base}\` and the \`compare\`/\`head\` branch is \`${head}\`., [click here to create the pull request](https://github.com/sourcegraph/sourcegraph/compare/${base}...${head}?expand=1).`,
-    "- [ ] Make sure to tag `@sourcegraph/release` in the pull request description.",
-    "- [ ] Once the backport pull request is created, kindly remove the `release-blocker` from this pull request.",
-    "",
-  ].join("\n");
-};
+  return `The backport to \`${base}\` failed at ${runUrl}:
+\`\`\`
+${errorMessage}
+\`\`\`
+
+To backport this PR manually, you can either:
+
+<details>
+<summary>Via the sg tool</summary>
+
+Use the \`sg backport\` command to backport your commit to the release branch.
+
+\`\`\`bash
+sg backport -r ${base} -p ${prNumber}
+\`\`\`
+</details>
+
+<details>
+<summary>
+Via your terminal
+</summary>
+
+To backport manually, run these commands in your terminal:
+
+\`\`\`bash
+# Fetch latest updates from GitHub
+git fetch
+# Create a new working tree
+git worktree add ${worktreePath} ${base}
+# Navigate to the new working tree
+cd ${worktreePath}
+# Create a new branch
+git switch --create ${head}
+# Cherry-pick the merged commit of this pull request and resolve the conflicts
+git cherry-pick -x --mainline 1 ${commitSha}
+# Push it to GitHub
+git push --set-upstream origin ${head}
+# Go back to the original working tree
+cd ../..
+# Delete the working tree
+git worktree remove ${worktreePath}
+\`\`\`
+
+If you encouter conflict, first resolve the conflict and stage all files, then run the commands below:
+\`\`\`bash
+git cherry-pick --continue
+# Push it to GitHub
+git push --set-upstream origin ${head}
+# Go back to the original working tree
+cd ../..
+# Delete the working tree
+git worktree remove ${worktreePath}
+\`\`\`
+
+- [ ] Follow above instructions to backport the commit.
+- [ ] Create a pull request where the \`base\` branch is \`${base}\` and the \`compare\`/\`head\` branch is \`${head}\`., [click here to create the pull request](https://github.com/sourcegraph/sourcegraph/compare/${base}...${head}?expand=1).
+</details>
+
+Once the pull request has been created, please ensure the following:
+
+- [ ] Make sure to tag \`@sourcegraph/release\` in the pull request description.
+
+- [ ] kindly remove the \`release-blocker\` from this pull request.
+`};
 
 const backport = async ({
   getBody,
@@ -346,6 +369,7 @@ const backport = async ({
               errorMessage: error.message,
               head,
               runUrl,
+              number,
             }),
             issue_number: number,
             owner,


### PR DESCRIPTION
This PR further simplifies how we display failed backport messages and gives alternative options to creating manual backports.

[#60489](https://github.com/sourcegraph/sourcegraph/pull/60489) added the backport functionality to the `sg` tool.

| BEFORE  |  AFTER |
|---|---|
| ![CleanShot 2024-03-21 at 11 10 43@2x](https://github.com/sourcegraph/backport/assets/25608335/f505ce31-ce6c-4082-9145-ec6d92129e29)  | <video src="https://github.com/sourcegraph/backport/assets/25608335/a90ad1f9-d612-4f09-9f10-dad84b94a844" width="320" height="240" controls></video>  |