### PR TITLE
Restrict backport action to vX.X.x branches

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,6 @@ inputs:
     description: >
       The regular expression pattern that PR labels will be tested on to decide whether the PR should be backported and where.
       The backport PR's base branch will be extracted from the pattern's required `base` named capturing group.
-    # default: "^backport (?<base>([^ ]+))$"
     default: '^backport (?<base>\d+\.\d+\.x)$'
   title_template:
     description: >

--- a/action.yml
+++ b/action.yml
@@ -29,7 +29,7 @@ inputs:
       The regular expression pattern that PR labels will be tested on to decide whether the PR should be backported and where.
       The backport PR's base branch will be extracted from the pattern's required `base` named capturing group.
     # default: "^backport (?<base>([^ ]+))$"
-    default: "^backport (?<base>\d+\.\d+\.x)$"
+    default: '^backport (?<base>\d+\.\d+\.x)$'
   title_template:
     description: >
       Lodash template for the backport PR's title.

--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,8 @@ inputs:
     description: >
       The regular expression pattern that PR labels will be tested on to decide whether the PR should be backported and where.
       The backport PR's base branch will be extracted from the pattern's required `base` named capturing group.
-    default: "^backport (?<base>([^ ]+))$"
+    # default: "^backport (?<base>([^ ]+))$"
+    default: "^backport (?<base>\d+\.\d+\.x)$"
   title_template:
     description: >
       Lodash template for the backport PR's title.


### PR DESCRIPTION
Restrict backport github action to only trigger on backports to X.X.x branches i.e. labels:
`backport 5.4.x` or `backport 5.3.x` this conforms to the new release policy at Sourcegraph: https://www.notion.so/sourcegraph/Release-Process-7fb8aff26cbe4c3786ca25396b4986d0