### PR TITLE
feat: make team reviews a parameter

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,10 @@ inputs:
         - base: backport PR's base branch
         - number: original PR's number
     default: "backport-<%= number %>-to-<%= base %>"
+  team_reviews:
+    description: Whether to request reviews from the team.
+    required: false
+    default: "release"
   label_pattern:
     description: >
       The regular expression pattern that PR labels will be tested on to decide whether the PR should be backported and where.

--- a/src/backport.ts
+++ b/src/backport.ts
@@ -87,6 +87,7 @@ const backportOnce = async ({
   merged_by,
   owner,
   repo,
+  teamReviews,
   title,
 }: Readonly<{
   author: string;
@@ -99,6 +100,7 @@ const backportOnce = async ({
   merged_by: string;
   owner: string;
   repo: string;
+  teamReviews: string;
   title: string;
 }>): Promise<number> => {
   const git = async (...args: string[]) => {
@@ -135,7 +137,7 @@ const backportOnce = async ({
         author !== merged_by && merged_by !== ""
           ? [author, merged_by]
           : [author],
-      team_reviewers: ["release"],
+      ...(teamReviews !== "" && { team_reviewers: [teamReviews] })
     },
   );
   if (labels.length > 0) {
@@ -243,6 +245,7 @@ const backport = async ({
   payload,
   runId,
   serverUrl,
+  teamReviews,
   token,
 }: {
   getBody: (
@@ -270,6 +273,7 @@ const backport = async ({
   payload: PullRequestClosedEvent | PullRequestLabeledEvent;
   runId: number;
   serverUrl: string;
+  teamReviews: string,
   token: string;
 }): Promise<{ [base: string]: number }> => {
   const {
@@ -354,6 +358,7 @@ const backport = async ({
           merged_by,
           owner,
           repo,
+          teamReviews,
           title,
         });
         createdPullRequestBaseBranchToNumber[base] = backportPullRequestNumber;

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ const run = async () => {
 
     const labelPattern = getInput("label_pattern");
     const labelRegExp = new RegExp(labelPattern);
+    const teamReviews = getInput("team_reviews");
 
     const token = getInput("github_token", { required: true });
 
@@ -40,6 +41,7 @@ const run = async () => {
       payload,
       runId,
       serverUrl,
+      teamReviews,
       token,
     });
     setOutput(


### PR DESCRIPTION
Previously, all PRs automatically added the sourcegrapm/team/release
reviewer to PRs. That worked fine while we were only using this on
Monorepo, but now we're expanding usage to Cody, Jetbrains and the
Deploy-* repos. Cody and Jetbrains particularly do not have the release
team as collaborator which caused errors while using this automation.

We're keeping the default the same with this change, but now we can
optionally override the default to change the team, or remove it
entirely (setting teamReviews = "").
