### PR TITLE
fix: use unescaped interpolation for PR body template

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ inputs:
         - body: original PR's body
         - mergeCommitSha: SHA of the original PR's merge commit
         - number: original PR's number
-    default: "<%- body %> <br> Backport <%= mergeCommitSha %> from #<%= number %>"
+    default: "Backport <%= mergeCommitSha %> from #<%= number %>\n\n<%= body %>"
   github_token:
     description: Token for the GitHub API.
     required: true


### PR DESCRIPTION
## Problem

The `body_template` was using `<%- body %>` which applies HTML entity escaping in Lodash templates. This caused HTML content like `<img>` tags to be converted to `&lt;img&gt;` in backport PR descriptions.

For example, a source PR with:
```html
<img width="1932" height="1200" alt="image" src="..." />
```

Would become in the backport PR:
```
&lt;img width=&quot;1932&quot; height=&quot;1200&quot; alt=&quot;image&quot; src=&quot;...&quot; /&gt;
```

## Solution

Changed `<%- body %>` to `<%= body %>` to preserve the original PR body content without HTML escaping.

## References

- Lodash template docs: https://lodash.com/docs/4.17.15#template
  - `<%- ... %>`: HTML-escape interpolated value
  - `<%= ... %>`: Interpolate value without escaping